### PR TITLE
Update kIOMasterPortDefault to kIOMainPortDefault

### DIFF
--- a/smc.c
+++ b/smc.c
@@ -57,7 +57,7 @@ kern_return_t SMCOpen(void)
     io_object_t   device;
 
     CFMutableDictionaryRef matchingDictionary = IOServiceMatching("AppleSMC");
-    result = IOServiceGetMatchingServices(kIOMasterPortDefault, matchingDictionary, &iterator);
+    result = IOServiceGetMatchingServices(kIOMainPortDefault, matchingDictionary, &iterator);
     if (result != kIOReturnSuccess)
     {
         printf("Error: IOServiceGetMatchingServices() = %08x\n", result);


### PR DESCRIPTION
kIOMasterPortDefault is deprecated in macOS >12.0, so this generates compilers warnings on newer SDKs:
```
(13:15:28) INFO: From GoCompilePkg external/com_github_matt_e_go_smc/go-smc.a:
external/com_github_matt_e_go_smc/smc.c:60:43: warning: 'kIOMasterPortDefault' is deprecated: first deprecated in macOS 12.0 [-Wdeprecated-declarations]
    result = IOServiceGetMatchingServices(kIOMasterPortDefault, matchingDictionary, &iterator);
```